### PR TITLE
[Warlock] Set target of Hand of Guldan impact

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -244,6 +244,7 @@ struct hand_of_guldan_t : public demonology_spell_t
   {
     demonology_spell_t::impact( s );
 
+    impact_spell->set_target( s->target );
     impact_spell->execute();    
 
     if ( p()->legendary.forces_of_the_horned_nightmare.ok() &&


### PR DESCRIPTION
Sets the target of Hand of Guldan's impact spell.